### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,25 +6,25 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Runnable			KEYWORD1
+Runnable	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-runWithSemaphore		KEYWORD2
-runWithDelay			KEYWORD2
-runNow				KEYWORD2
-stopNow				KEYWORD2
-runnableExec			KEYWORD2
-isRunning			KEYWORD2
-remainder			KEYWORD2
+runWithSemaphore	KEYWORD2
+runWithDelay	KEYWORD2
+runNow	KEYWORD2
+stopNow	KEYWORD2
+runnableExec	KEYWORD2
+isRunning	KEYWORD2
+remainder	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-RUN_TASKS			LITERAL1
-RUN_NEVER			LITERAL1
-RUN_DELETE			LITERAL1
-RUN_NOW				LITERAL1
+RUN_TASKS	LITERAL1
+RUN_NEVER	LITERAL1
+RUN_DELETE	LITERAL1
+RUN_NOW	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords